### PR TITLE
36 Fix broken navigation links

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -160,11 +160,11 @@ navigation:
 
       children:
 
-            - title: 00-pre-deploy
-              location: dev-manual.md#00-pre-deploy
+            - title: 00_pre-deploy
+              location: dev-manual.md#00_pre-deploy
 
-            - title: 00-deploy-done
-              location: dev-manual.md#00-deploy-done
+            - title: 00_deploy-done
+              location: dev-manual.md#00_deploy-done
 
     - title: Post processing
       location: dev-manual.md#post-processing

--- a/templates/devel/en/cni/k8s-and-aws.html
+++ b/templates/devel/en/cni/k8s-and-aws.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/conjurefile.html
+++ b/templates/devel/en/conjurefile.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/dev-manual.html
+++ b/templates/devel/en/dev-manual.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/index.html
+++ b/templates/devel/en/index.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/providers/vsphere.html
+++ b/templates/devel/en/providers/vsphere.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/spellbooks.html
+++ b/templates/devel/en/spellbooks.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/spellbooks/kubernetes.html
+++ b/templates/devel/en/spellbooks/kubernetes.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/spellbooks/openstack.html
+++ b/templates/devel/en/spellbooks/openstack.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/troubleshoot.html
+++ b/templates/devel/en/troubleshoot.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/usage.html
+++ b/templates/devel/en/usage.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/user-manual.html
+++ b/templates/devel/en/user-manual.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/devel/en/walkthrough.html
+++ b/templates/devel/en/walkthrough.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/cni/k8s-and-aws.html
+++ b/templates/stable/en/cni/k8s-and-aws.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/conjurefile.html
+++ b/templates/stable/en/conjurefile.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/dev-manual.html
+++ b/templates/stable/en/dev-manual.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/index.html
+++ b/templates/stable/en/index.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/providers/vsphere.html
+++ b/templates/stable/en/providers/vsphere.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/spellbooks.html
+++ b/templates/stable/en/spellbooks.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/spellbooks/kubernetes.html
+++ b/templates/stable/en/spellbooks/kubernetes.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/spellbooks/openstack.html
+++ b/templates/stable/en/spellbooks/openstack.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="../dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="../dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="../dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/troubleshoot.html
+++ b/templates/stable/en/troubleshoot.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/usage.html
+++ b/templates/stable/en/usage.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/user-manual.html
+++ b/templates/stable/en/user-manual.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         

--- a/templates/stable/en/walkthrough.html
+++ b/templates/stable/en/walkthrough.html
@@ -569,13 +569,13 @@
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-pre-deploy">00-pre-deploy</a>
+                              <a class="p-link--soft" href="dev-manual#00_pre-deploy">00_pre-deploy</a>
                             
                           </li>
                         
                           <li class="p-sidebar-nav__item">
                             
-                              <a class="p-link--soft" href="dev-manual#00-deploy-done">00-deploy-done</a>
+                              <a class="p-link--soft" href="dev-manual#00_deploy-done">00_deploy-done</a>
                             
                           </li>
                         


### PR DESCRIPTION
## Done

- change first dashes in 00-pre-deploy and 00-deploy-done to underscores to match title IDs

## QA

- Checkout this branch
- Run `./run`
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- On any page, in the main navigation, find `00_pre-deploy` and `00_deploy-done`, click both links, and see that the relevant sections of the `/dev-manual` page are in view on page load.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/conjure-up.io/issues/36
