### PR TITLE
Upgrade focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 install:
   - git clone https://github.com/evilnick/documentation-builder
   - pip install ./documentation-builder
+  - pip install gitdb2==3.0.1
  
 script:
   - python3 ./documentation-builder/documentation-builder

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,10 @@ dist: trusty
 python:
   - "3.5"
 
-before_install:
-  - pip install requests
-
 install:
-  - git clone https://github.com/evilnick/documentation-builder
-  - pip install ./documentation-builder
-  - pip install gitdb2==3.0.1
- 
+  - pip3 install -r requirements.txt
+
 script:
-  - python3 ./documentation-builder/documentation-builder
+  - documentation-builder
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # Set up environment
 ENV LANG C.UTF-8
@@ -8,14 +8,14 @@ WORKDIR /srv
 RUN apt-get update && apt-get install --yes nginx net-tools
 
 # Set git commit ID
-ARG REVISION_ID
-RUN test -n "${REVISION_ID}"
+ARG BUILD_ID
+RUN test -n "${BUILD_ID}"
 
 # Copy over files
 ADD build .
 ADD nginx.conf /etc/nginx/sites-enabled/default
 ADD redirects.map /etc/nginx/redirects.map
-RUN sed -i "s/~REVISION_ID~/${REVISION_ID}/" /etc/nginx/sites-enabled/default
+RUN sed -i "s/~BUILD_ID~/${BUILD_ID}/" /etc/nginx/sites-enabled/default
 RUN sed -i "s/8204/80/" /etc/nginx/sites-enabled/default
 
 STOPSIGNAL SIGTERM

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,7 +19,7 @@ server {
     error_page 404 /404.html;
 
     # Show commit-id
-    add_header x-vcs-revision ~REVISION_ID~ always;
+    add_header x-vcs-revision ~BUILD_ID~ always;
     add_header x-hostname $hostname always;
 
     # Apply redirects from file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-ubuntudesign.documentation-builder==1.6.1
+ubuntudesign.documentation-builder==1.6.2
+gitdb2==3.0.1

--- a/templates/devel/en/index.html
+++ b/templates/devel/en/index.html
@@ -688,7 +688,7 @@
                 
                 <li class="p-inline-list__item"><a href="https://www.ubuntu.com/legal">Legal information</a></li>
                 
-                <li class="p-inline-list__item"><a href="https://github.com/CanonicalLtd/maas-docs/issues/new">Report a bug on this site</a></li>
+                <li class="p-inline-list__item"><a href="https://github.com/canonical-web-and-design/docs.conjure-up.io/issues/new">Report a bug on this site</a></li>
                 
               </ul>
               

--- a/templates/stable/en/index.html
+++ b/templates/stable/en/index.html
@@ -688,7 +688,7 @@
                 
                 <li class="p-inline-list__item"><a href="https://www.ubuntu.com/legal">Legal information</a></li>
                 
-                <li class="p-inline-list__item"><a href="https://github.com/CanonicalLtd/maas-docs/issues/new">Report a bug on this site</a></li>
+                <li class="p-inline-list__item"><a href="https://github.com/canonical-web-and-design/docs.conjure-up.io/issues/new">Report a bug on this site</a></li>
                 
               </ul>
               


### PR DESCRIPTION
# Done

- Pin gitdb: see here https://github.com/canonical-web-and-design/docs.ubuntu.com/pull/234
- Upgrade images to focal
- Use build_id instead of revision id which is our pattern

# QA

- `./run build`
- `docker build --build-arg BUILD_ID=build_id -t docs.conjure-up.io .`
- `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key docs.conjure-up.io`
- http://localhost:8006/stable/en/
- Play around the site. Should be as usual